### PR TITLE
Fix overload ambiguity between LosslessStringConvertible and RawRepresentable types

### DIFF
--- a/Sources/XMLWrangler/ElementContent+Lookup.swift
+++ b/Sources/XMLWrangler/ElementContent+Lookup.swift
@@ -25,11 +25,8 @@ public extension Sequence where Element == XMLWrangler.Element.Content {
    internal func find(recursive: Bool = false, elementsMatching predicate: (XMLWrangler.Element) throws -> Bool) rethrows -> [XMLWrangler.Element] {
       let objects = allObjects
       let matches = try objects.filter(predicate)
-      if recursive {
-         return try matches + objects.flatMap { try $0.content.find(recursive: recursive, elementsMatching: predicate) }
-      } else {
-         return matches
-      }
+      guard recursive else { return matches }
+      return try matches + objects.flatMap { try $0.content.find(recursive: recursive, elementsMatching: predicate) }
    }
 
    /// Finds the first occurence of an element that matches a given predicate.
@@ -46,11 +43,8 @@ public extension Sequence where Element == XMLWrangler.Element.Content {
    internal func findFirst(recursive: Bool = false, elementMatching predicate: (XMLWrangler.Element) throws -> Bool) rethrows -> XMLWrangler.Element? {
       let objects = allObjects
       let match = try objects.first(where: predicate)
-      if recursive {
-         return try match ?? objects.mapFirst { try $0.content.findFirst(recursive: recursive, elementMatching: predicate) }
-      } else {
-         return match
-      }
+      guard recursive else { return match }
+      return try match ?? objects.mapFirst { try $0.content.findFirst(recursive: recursive, elementMatching: predicate) }
    }
 
    /// Finds the last occurence of an element that matches a given predicate.
@@ -67,11 +61,8 @@ public extension Sequence where Element == XMLWrangler.Element.Content {
    internal func findLast(recursive: Bool = false, elementMatching predicate: (XMLWrangler.Element) throws -> Bool) rethrows -> XMLWrangler.Element? {
       let objects = allObjects.reversed()
       let match = try objects.first(where: predicate)
-      if recursive {
-         return try match ?? objects.mapFirst { try $0.content.findLast(recursive: recursive, elementMatching: predicate) }
-      } else {
-         return match
-      }
+      guard recursive else { return match }
+      return try match ?? objects.mapFirst { try $0.content.findLast(recursive: recursive, elementMatching: predicate) }
    }
 
    /// Searches for elements with a given name. Optionally also recursive.

--- a/Tests/XMLWranglerTests/ElementContent+DeprecatedTests.swift
+++ b/Tests/XMLWranglerTests/ElementContent+DeprecatedTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import XMLWrangler
+
+@available(*, deprecated, message: "Tests deprecated API")
+final class ElementContent_DeprecatedTests: XCTestCase {
+   private struct StringConvertible: LosslessStringConvertible, Equatable {
+      let description: String
+      init(_ description: String) { self.description = description }
+   }
+
+   func testElementContentConverted() {
+      let content = Element.Content.string("Test")
+      XCTAssertEqual(content.converted(), StringConvertible("Test"))
+   }
+
+   func testElementContentAppend() {
+      let testElement = Element(name: "Unused")
+      var objContent = Element.Content.object(testElement)
+      var strContent = Element.Content.string("Test")
+      objContent.append(string: "Something")
+      strContent.append(string: "Again")
+      XCTAssertEqual(strContent, .string("TestAgain"))
+      XCTAssertEqual(objContent, .object(testElement))
+   }
+}

--- a/Tests/XMLWranglerTests/ErrorsTests.swift
+++ b/Tests/XMLWranglerTests/ErrorsTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import XMLWrangler
+
+final class ErrorsTests: XCTestCase {
+   func testLookupErrorDescription() {
+      let testElement = Element(name: "Root")
+      let testKey = Element.Attributes.Key(rawValue: "TestKey")
+      let testName = Element.Name(rawValue: "TestName")
+      let testContent = "Test Content"
+      let testType = Int32.self
+
+      let missingAttribute = LookupError.missingAttribute(element: testElement, key: testKey)
+      let cannotConvertAttribute = LookupError.cannotConvertAttribute(element: testElement, key: testKey, type: testType)
+      let missingContent = LookupError.missingContent(element: testElement)
+      let missingChild = LookupError.missingChild(element: testElement, childElementName: testName)
+      let cannotConvertContent = LookupError.cannotConvertContent(element: testElement, content: testContent, type: testType)
+
+      XCTAssertEqual(String(describing: missingAttribute),
+                     "Element \"\(testElement.name.rawValue)\" has no attribute \"\(testKey.rawValue)\"!\nAttributes: \(testElement.attributes)")
+      XCTAssertEqual(String(describing: cannotConvertAttribute),
+                     "Could not convert attribute \"\(testKey.rawValue)\" of element \"\(testElement.name.rawValue)\" to \(testType)!\nAttribute value: \(testElement.attributes[testKey] ?? "nil")")
+      XCTAssertEqual(String(describing: missingContent),
+                     "Element \"\(testElement.name.rawValue)\" has no content!")
+      XCTAssertEqual(String(describing: missingChild),
+                     "Element \"\(testElement.name.rawValue)\" has no child named \"\(testName.rawValue)\"")
+      XCTAssertEqual(String(describing: cannotConvertContent),
+                     "Could not convert content of element \"\(testElement.name.rawValue)\" to \(testType)!\nContent: \(testContent)")
+   }
+
+   func testParserUnknownError() {
+      XCTAssertEqual(String(describing: Parser.UnknownError()), "An unknown parsing error occurred!")
+   }
+
+   func testParserMissingObjectError() {
+      XCTAssertEqual(String(describing: Parser.MissingObjectError()), "Parsing did not yield an object! Please check that the XML is valid!")
+   }
+}

--- a/Tests/XMLWranglerTests/SerializationTests.swift
+++ b/Tests/XMLWranglerTests/SerializationTests.swift
@@ -3,18 +3,24 @@ import XCTest
 
 final class SerializationTests: XCTestCase {
 
-   func testEscapeableContentEquality() {
-      let content1: EscapableContent = .attribute(quotes: .single)
-      let content2: EscapableContent = .attribute(quotes: .single)
-      let content3: EscapableContent = .attribute(quotes: .double)
-      let content4: EscapableContent = .comment
-      let content5: EscapableContent = .comment
+   func testDocumentEncodingDescription() {
+      XCTAssertEqual(String(describing: DocumentEncoding.ascii), "ascii")
+      XCTAssertEqual(String(describing: DocumentEncoding.utf8), "utf-8")
+      XCTAssertEqual(String(describing: DocumentEncoding.utf16), "utf-16")
+   }
 
-      XCTAssertEqual(content1, content2)
-      XCTAssertEqual(content4, content5)
-      XCTAssertNotEqual(content2, content3)
-      XCTAssertNotEqual(content1, content3)
-      XCTAssertNotEqual(content3, content5)
+   func testEscapableContentQuotesDescription() {
+      XCTAssertEqual(String(describing: EscapableContent.Quotes.single), "Single quotes")
+      XCTAssertEqual(String(describing: EscapableContent.Quotes.double), "Double quotes")
+   }
+
+   func testEscapableContentDescription() {
+      XCTAssertEqual(String(describing: EscapableContent.attribute(quotes: .single)), "Attribute enclosed in single quotes")
+      XCTAssertEqual(String(describing: EscapableContent.attribute(quotes: .double)), "Attribute enclosed in double quotes")
+      XCTAssertEqual(String(describing: EscapableContent.text), "Text")
+      XCTAssertEqual(String(describing: EscapableContent.cdata), "CDATA")
+      XCTAssertEqual(String(describing: EscapableContent.comment), "Comment")
+      XCTAssertEqual(String(describing: EscapableContent.processingInstruction), "Processing instruction")
    }
 
    func testEscapingStrings() {

--- a/Tests/XMLWranglerTests/XCTestManifests.swift
+++ b/Tests/XMLWranglerTests/XCTestManifests.swift
@@ -13,6 +13,14 @@ extension ElementContentTests {
     ]
 }
 
+@available(*, deprecated, message: "Tests deprecated API")
+extension ElementContent_DeprecatedTests {
+    static let __allTests = [
+        ("testElementContentAppend", testElementContentAppend),
+        ("testElementContentConverted", testElementContentConverted),
+    ]
+}
+
 extension ElementContent_LookupTests {
     static let __allTests = [
         ("testFindingFirstObjectRecursive", testFindingFirstObjectRecursive),
@@ -86,9 +94,23 @@ extension Element_LookupTests {
         ("testRawRepresentableAttributeConversion", testRawRepresentableAttributeConversion),
         ("testRawRepresentableAttributeConversionAtPath", testRawRepresentableAttributeConversionAtPath),
         ("testRawRepresentableAttributeConversionAtVariadicPath", testRawRepresentableAttributeConversionAtVariadicPath),
+        ("testRawRepresentableLosslessStringConvertibleAttributeConversion", testRawRepresentableLosslessStringConvertibleAttributeConversion),
+        ("testRawRepresentableLosslessStringConvertibleAttributeConversionAtPath", testRawRepresentableLosslessStringConvertibleAttributeConversionAtPath),
+        ("testRawRepresentableLosslessStringConvertibleAttributeConversionAtVariadicPath", testRawRepresentableLosslessStringConvertibleAttributeConversionAtVariadicPath),
+        ("testRawRepresentableLosslessStringConvertibleStringContentConversion", testRawRepresentableLosslessStringConvertibleStringContentConversion),
+        ("testRawRepresentableLosslessStringConvertibleStringContentConversionAtPath", testRawRepresentableLosslessStringConvertibleStringContentConversionAtPath),
+        ("testRawRepresentableLosslessStringConvertibleStringContentConversionAtVariadicPath", testRawRepresentableLosslessStringConvertibleStringContentConversionAtVariadicPath),
         ("testRawRepresentableStringContentConversion", testRawRepresentableStringContentConversion),
         ("testRawRepresentableStringContentConversionAtPath", testRawRepresentableStringContentConversionAtPath),
         ("testRawRepresentableStringContentConversionAtVariadicPath", testRawRepresentableStringContentConversionAtVariadicPath),
+    ]
+}
+
+extension ErrorsTests {
+    static let __allTests = [
+        ("testLookupErrorDescription", testLookupErrorDescription),
+        ("testParserMissingObjectError", testParserMissingObjectError),
+        ("testParserUnknownError", testParserUnknownError),
     ]
 }
 
@@ -103,7 +125,9 @@ extension ParserTests {
 
 extension SerializationTests {
     static let __allTests = [
-        ("testEscapeableContentEquality", testEscapeableContentEquality),
+        ("testDocumentEncodingDescription", testDocumentEncodingDescription),
+        ("testEscapableContentDescription", testEscapableContentDescription),
+        ("testEscapableContentQuotesDescription", testEscapableContentQuotesDescription),
         ("testEscapingStrings", testEscapingStrings),
         ("testMixedContentSerialization", testMixedContentSerialization),
         ("testXMLDocumentSerialization", testXMLDocumentSerialization),
@@ -115,9 +139,11 @@ extension SerializationTests {
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ElementContentTests.__allTests),
+        testCase(ElementContent_DeprecatedTests.__allTests),
         testCase(ElementContent_LookupTests.__allTests),
         testCase(ElementTests.__allTests),
         testCase(Element_LookupTests.__allTests),
+        testCase(ErrorsTests.__allTests),
         testCase(ParserTests.__allTests),
         testCase(SerializationTests.__allTests),
     ]

--- a/Tests/XMLWranglerTests/XCTestManifests.swift
+++ b/Tests/XMLWranglerTests/XCTestManifests.swift
@@ -68,6 +68,8 @@ extension Element_LookupTests {
         ("testFailedExistingStringContentConversion", testFailedExistingStringContentConversion),
         ("testFailedExistingStringContentConversionAtPath", testFailedExistingStringContentConversionAtPath),
         ("testFailedExistingStringContentConversionAtVariadicPath", testFailedExistingStringContentConversionAtVariadicPath),
+        ("testFailedRawRepresentableAttributeConversion", testFailedRawRepresentableAttributeConversion),
+        ("testFailedRawRepresentableExistingStringContentConversion", testFailedRawRepresentableExistingStringContentConversion),
         ("testLosslessStringConvertibleAttributeConversion", testLosslessStringConvertibleAttributeConversion),
         ("testLosslessStringConvertibleAttributeConversionAtPath", testLosslessStringConvertibleAttributeConversionAtPath),
         ("testLosslessStringConvertibleAttributeConversionAtVariadicPath", testLosslessStringConvertibleAttributeConversionAtVariadicPath),

--- a/Xcode/XMLWrangler.xcodeproj/project.pbxproj
+++ b/Xcode/XMLWrangler.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		07426D4221DE5D6A00393E78 /* XMLWrangler.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07426D3821DE5D6A00393E78 /* XMLWrangler.framework */; };
 		07426D7321DE610100393E78 /* SemVer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07426D7221DE610100393E78 /* SemVer.framework */; };
+		0774CFC921F639B500C3D5CB /* ErrorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0774CFC721F6398C00C3D5CB /* ErrorsTests.swift */; };
+		0774CFCC21F63D1300C3D5CB /* ElementContent+DeprecatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0774CFCA21F63CF200C3D5CB /* ElementContent+DeprecatedTests.swift */; };
 		07783CF521F2366700585133 /* ElementContent+Mutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07783CEC21F2366700585133 /* ElementContent+Mutation.swift */; };
 		07783CF621F2366700585133 /* Element+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07783CED21F2366700585133 /* Element+Lookup.swift */; };
 		07783CF721F2366700585133 /* ElementContent+DeprecatedAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07783CEE21F2366700585133 /* ElementContent+DeprecatedAPI.swift */; };
@@ -41,6 +43,8 @@
 		07426D3821DE5D6A00393E78 /* XMLWrangler.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XMLWrangler.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		07426D4121DE5D6A00393E78 /* XMLWranglerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMLWranglerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		07426D7221DE610100393E78 /* SemVer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SemVer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0774CFC721F6398C00C3D5CB /* ErrorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorsTests.swift; sourceTree = "<group>"; };
+		0774CFCA21F63CF200C3D5CB /* ElementContent+DeprecatedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ElementContent+DeprecatedTests.swift"; sourceTree = "<group>"; };
 		07783CEC21F2366700585133 /* ElementContent+Mutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ElementContent+Mutation.swift"; sourceTree = "<group>"; };
 		07783CED21F2366700585133 /* Element+Lookup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Element+Lookup.swift"; sourceTree = "<group>"; };
 		07783CEE21F2366700585133 /* ElementContent+DeprecatedAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ElementContent+DeprecatedAPI.swift"; sourceTree = "<group>"; };
@@ -113,14 +117,14 @@
 		07783CEB21F2366700585133 /* XMLWrangler */ = {
 			isa = PBXGroup;
 			children = (
-				07783CEC21F2366700585133 /* ElementContent+Mutation.swift */,
-				07783CED21F2366700585133 /* Element+Lookup.swift */,
-				07783CEE21F2366700585133 /* ElementContent+DeprecatedAPI.swift */,
 				07783CEF21F2366700585133 /* Element.swift */,
+				07783CED21F2366700585133 /* Element+Lookup.swift */,
+				07783CF321F2366700585133 /* ElementContent+InternalHelpers.swift */,
 				07783CF021F2366700585133 /* ElementContent+Lookup.swift */,
+				07783CEC21F2366700585133 /* ElementContent+Mutation.swift */,
+				07783CEE21F2366700585133 /* ElementContent+DeprecatedAPI.swift */,
 				07783CF121F2366700585133 /* LookupError.swift */,
 				07783CF221F2366700585133 /* Parser.swift */,
-				07783CF321F2366700585133 /* ElementContent+InternalHelpers.swift */,
 				07783CF421F2366700585133 /* Serialization.swift */,
 				07783CFE21F2366C00585133 /* Supporting Files */,
 			);
@@ -140,12 +144,14 @@
 		07783D1221F236BE00585133 /* XMLWranglerTests */ = {
 			isa = PBXGroup;
 			children = (
-				07783D1321F236BE00585133 /* ElementContent+LookupTests.swift */,
-				07783D1521F236BE00585133 /* ParserTests.swift */,
 				07783D1621F236BE00585133 /* Element+LookupTests.swift */,
+				0774CFCA21F63CF200C3D5CB /* ElementContent+DeprecatedTests.swift */,
+				07783D1321F236BE00585133 /* ElementContent+LookupTests.swift */,
 				07783D1721F236BE00585133 /* ElementContentTests.swift */,
-				07783D1821F236BE00585133 /* SerializationTests.swift */,
 				07783D1921F236BE00585133 /* ElementTests.swift */,
+				0774CFC721F6398C00C3D5CB /* ErrorsTests.swift */,
+				07783D1521F236BE00585133 /* ParserTests.swift */,
+				07783D1821F236BE00585133 /* SerializationTests.swift */,
 				07783D2121F236C500585133 /* Supporting Files */,
 			);
 			name = XMLWranglerTests;
@@ -289,9 +295,11 @@
 				07783D1A21F236BE00585133 /* ElementContent+LookupTests.swift in Sources */,
 				07783D1D21F236BE00585133 /* Element+LookupTests.swift in Sources */,
 				07783D2021F236BE00585133 /* ElementTests.swift in Sources */,
+				0774CFCC21F63D1300C3D5CB /* ElementContent+DeprecatedTests.swift in Sources */,
 				07783D1C21F236BE00585133 /* ParserTests.swift in Sources */,
 				07783D1F21F236BE00585133 /* SerializationTests.swift in Sources */,
 				07783D1E21F236BE00585133 /* ElementContentTests.swift in Sources */,
+				0774CFC921F639B500C3D5CB /* ErrorsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This fixes the overload ambiguity between `RawRepresentable` and `LosslessStringConvertible` types. Also, the restriction for the `RawRepresentable` types was lifted to their `RawValue` being `LossLessStringConvertible`.